### PR TITLE
ignore __pycache__ folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/*
+__pycache__/*
+Test_Generator_Module/__pycache__/*


### PR DESCRIPTION
Hallo Tobias, 
dein repository könnte ein .gitignore gebrauchen. Damit kann man Ordner oder Dateien für die git/github-Synchronisierung ignorieren (hier z.B. __pycache__-Ordner). VG, Silvan